### PR TITLE
Add MCP search and fetch tools

### DIFF
--- a/MCP_USAGE.md
+++ b/MCP_USAGE.md
@@ -1,0 +1,29 @@
+# MCP Tools Usage
+
+This repository exposes two JavaScript functions that match the [Model Context Protocol](https://platform.openai.com/docs/mcp) tool signatures.
+
+- **search** – located in `search.js`
+- **fetch** – located in `fetch.js`
+
+Both functions replicate the behaviour of the sample HTML search page and can be used from Node.js modules.
+
+## Example
+
+```javascript
+const search = require('./search');
+const fetchPage = require('./fetch');
+
+async function run() {
+  const results = search('help');
+  console.log('search results:', results);
+
+  if (results.length) {
+    const page = await fetchPage(results[0].id);
+    console.log('fetched title:', page.title);
+  }
+}
+
+run();
+```
+
+The `search` function returns an array of objects with `id`, `title`, `text` and `url` fields. The `id` should be passed to `fetch` to retrieve the full HTML for that result. `fetch` returns an object with the same fields plus an empty `metadata` object.

--- a/fetch.js
+++ b/fetch.js
@@ -1,0 +1,23 @@
+const { exec } = require('child_process');
+
+const BASE = 'https://syncrosoftsrljustkidding.netlify.app/';
+
+/**
+ * Fetch the full HTML for a given search result.
+ * @param {string} id Identifier of the document (path returned by search)
+ * @returns {Promise<{id:string,title:string,text:string,url:string,metadata?:object}>}
+ */
+function fetchResult(id) {
+  const url = BASE + id;
+  return new Promise((resolve, reject) => {
+    exec(`curl -sL ${url}`, (error, stdout, stderr) => {
+      if (error) return reject(error);
+      const html = stdout.toString();
+      const titleMatch = html.match(/<title>([^<]*)<\/title>/i);
+      const title = titleMatch ? titleMatch[1] : id;
+      resolve({ id, title, text: html, url, metadata: {} });
+    });
+  });
+}
+
+module.exports = fetchResult;

--- a/search.js
+++ b/search.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const vm = require('vm');
+
+const context = {};
+['keywords.js','htmlFileInfoList.js','link-to-parent.js','stopwords.js','index-1.js','index-2.js','index-3.js'].forEach(f => {
+  const code = fs.readFileSync(require.resolve('./'+f), 'utf8');
+  vm.runInNewContext(code, context);
+});
+
+const words = Object.assign({}, context.index1, context.index2, context.index3);
+const index = {
+  w: words,
+  stopWords: context.stopwords,
+  fil: context.htmlFileInfoList,
+  link2parent: context.linkToParent
+};
+
+/**
+ * Search the local index using the MCP search tool signature.
+ * @param {string} query Search terms
+ * @returns {Array<{id:string,title:string,text:string,url:string}>} Ordered search results
+ */
+function search(query) {
+  query = query.toLowerCase();
+  const tokens = query.split(/\s+/).filter(t => t && !index.stopWords.includes(t));
+  const scores = {};
+  tokens.forEach(token => {
+    const entry = index.w[token];
+    if (!entry) return;
+    entry.split(',').forEach(seg => {
+      const [idStr, scoreStr] = seg.split('*');
+      const id = parseInt(idStr, 10);
+      const sc = parseInt(scoreStr, 10) || 0;
+      if (!scores[id]) scores[id] = 0;
+      scores[id] += sc;
+    });
+  });
+  return Object.entries(scores)
+    .sort((a,b) => b[1]-a[1])
+    .map(([id]) => {
+      const info = index.fil[id];
+      const [path, title, desc] = info.split('@@@');
+      const url = `https://syncrosoftsrljustkidding.netlify.app/${path}`;
+      return { id: path, title, text: desc, url };
+    });
+}
+
+module.exports = search;


### PR DESCRIPTION
## Summary
- implement `search` and `fetch` tools for the Model Context Protocol
- document how to use the new functions

## Testing
- `node -e "const search=require('./search');const fetchPage=require('./fetch');const r=search('help')[0];if(r){fetchPage(r.id).then(p=>console.log('ok',p.title.length>0));}"

------
https://chatgpt.com/codex/tasks/task_b_687b7f512c548331af656b94516c786f