### PR TITLE
docs: add infrastructure TODO list

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,12 @@
+# TODO
+
+1. Initialize Next.js App Router project with TypeScript and Tailwind.
+2. Configure Auth.js with Google OAuth and enforce allowlisted users.
+3. Set up Neon Postgres database and Drizzle ORM migrations.
+4. Build shared UI library in `src/ui` including `AppShell` and common components.
+5. Implement app registry and directory with search and favorites.
+6. Add API routes for apps, favorites, and allowlist management.
+7. Integrate `lib/ai.ts` to proxy AI calls through Vercel AI Gateway with fallback.
+8. Establish linting, type checking, testing, and build scripts for CI.
+9. Configure Vercel deployment and required environment variables.
+10. Provide templates and scaffolding for new sub-apps.


### PR DESCRIPTION
## Summary
- add repo-level TODO outline for core app infrastructure

## Testing
- `npm test` *(fails: could not read package.json)*
- `npm run lint` *(fails: could not read package.json)*
- `npm run build` *(fails: could not read package.json)*
- `npm run typecheck` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3ae6ee1483258f3b2f7ca96e8ac8