### PR TITLE
feat: add app directory with favorites

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 2. [x] Configure Auth.js with Google OAuth and enforce allowlisted users.
 3. [x] Set up Neon Postgres database and Drizzle ORM migrations.
 4. [x] Build shared UI library in `src/ui` including `AppShell` and common components.
-5. [ ] Implement app registry and directory with search and favorites.
+5. [x] Implement app registry and directory with search and favorites.
 6. [ ] Add API routes for apps, favorites, and allowlist management.
 7. [ ] Integrate `lib/ai.ts` to proxy AI calls through Vercel AI Gateway with fallback.
 8. [ ] Establish linting, type checking, testing, and build scripts for CI.

--- a/apps/hello/meta.json
+++ b/apps/hello/meta.json
@@ -1,0 +1,5 @@
+{
+  "name": "Hello App",
+  "description": "Sample app.",
+  "tags": ["sample"]
+}

--- a/drizzle/0001_adorable_domino.sql
+++ b/drizzle/0001_adorable_domino.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "favorites" (
+        "user_id" uuid NOT NULL,
+        "app_slug" text NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now(),
+        CONSTRAINT "favorites_user_id_app_slug_pk" PRIMARY KEY("user_id","app_slug")
+);
+--> statement-breakpoint
+ALTER TABLE "favorites" ADD CONSTRAINT "favorites_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,152 @@
+{
+  "id": "c82a3a30-ef23-4590-aa01-f69e801ef786",
+  "prevId": "86d42dd0-a10d-4a88-a21f-c0115edd8c90",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.allowed_users": {
+      "name": "allowed_users",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_slug": {
+          "name": "app_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_app_slug_pk": {
+          "name": "favorites_user_id_app_slug_pk",
+          "columns": [
+            "user_id",
+            "app_slug"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1756062425632,
       "tag": "0000_goofy_the_santerians",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1756067497468,
+      "tag": "0001_adorable_domino",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,12 @@
+"use server";
+
+import { auth } from "../lib/auth";
+import { toggleFavorite } from "../lib/registry";
+
+export async function toggleFavoriteAction(formData: FormData) {
+  const slug = formData.get("slug") as string;
+  const session = await auth();
+  const email = session?.user?.email;
+  if (!slug || !email) return;
+  await toggleFavorite(slug, email);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,60 @@
-import { Button } from "../ui";
+import { auth } from "../lib/auth";
+import { getApps } from "../lib/registry";
+import {
+  AppShell,
+  Input,
+  Card,
+  CardHeader,
+  CardContent,
+} from "../ui";
+import { toggleFavoriteAction } from "./actions";
 
-export default function Home() {
+interface HomeProps {
+  searchParams: { q?: string };
+}
+
+export default async function Home({ searchParams }: HomeProps) {
+  const session = await auth();
+  const email = session?.user?.email;
+  const q = searchParams.q ?? "";
+  const apps = await getApps(q, email || undefined);
+
   return (
-    <main className="flex flex-col gap-4 items-center justify-center">
-      <h1 className="text-2xl font-bold">Vibes</h1>
-      <Button>Get Started</Button>
-    </main>
+    <AppShell>
+      <form method="GET" className="mb-4">
+        <Input
+          name="q"
+          defaultValue={q}
+          placeholder="Search apps..."
+          aria-label="Search apps"
+        />
+      </form>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {apps.map((app) => (
+          <Card key={app.slug}>
+            <CardHeader className="flex items-center justify-between">
+              <span className="font-medium">{app.name}</span>
+              {email && (
+                <form action={toggleFavoriteAction}>
+                  <input type="hidden" name="slug" value={app.slug} />
+                  <button
+                    type="submit"
+                    aria-label={
+                      app.favorite ? "Remove from favorites" : "Add to favorites"
+                    }
+                    className="text-xl"
+                  >
+                    {app.favorite ? "★" : "☆"}
+                  </button>
+                </form>
+              )}
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-gray-600">{app.description}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </AppShell>
   );
 }

--- a/src/lib/apps.ts
+++ b/src/lib/apps.ts
@@ -1,0 +1,25 @@
+import fs from "fs";
+import path from "path";
+
+export interface AppMeta {
+  slug: string;
+  name: string;
+  description?: string;
+  tags?: string[];
+}
+
+function loadMeta(dir: string): AppMeta | null {
+  const metaPath = path.join(dir, "meta.json");
+  if (!fs.existsSync(metaPath)) return null;
+  const raw = fs.readFileSync(metaPath, "utf8");
+  const meta = JSON.parse(raw);
+  return { slug: path.basename(dir), ...meta } as AppMeta;
+}
+
+const appsDir = path.join(process.cwd(), "apps");
+export const allApps: AppMeta[] = fs.existsSync(appsDir)
+  ? fs
+      .readdirSync(appsDir)
+      .map((slug) => loadMeta(path.join(appsDir, slug)))
+      .filter((m): m is AppMeta => !!m)
+  : [];

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,0 +1,55 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "./db";
+import { favorites, users } from "./schema";
+import { allApps } from "./apps";
+
+export async function getOrCreateUserByEmail(email: string) {
+  const [existing] = await db.select().from(users).where(eq(users.email, email));
+  if (existing) return existing;
+  const [inserted] = await db
+    .insert(users)
+    .values({ email })
+    .returning();
+  return inserted;
+}
+
+export async function getApps(search: string, email?: string) {
+  const q = search.toLowerCase();
+  const list = allApps
+    .filter((a) =>
+      q
+        ? a.name.toLowerCase().includes(q) ||
+          (a.description && a.description.toLowerCase().includes(q)) ||
+          a.tags?.some((t) => t.toLowerCase().includes(q))
+        : true
+    )
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  if (!email) return list.map((a) => ({ ...a, favorite: false }));
+
+  const user = await getOrCreateUserByEmail(email);
+  const favRows = await db
+    .select({ appSlug: favorites.appSlug })
+    .from(favorites)
+    .where(eq(favorites.userId, user.id));
+  const favSet = new Set(favRows.map((f) => f.appSlug));
+  const withFav = list.map((a) => ({ ...a, favorite: favSet.has(a.slug) }));
+  withFav.sort((a, b) => Number(b.favorite) - Number(a.favorite));
+  return withFav;
+}
+
+export async function toggleFavorite(appSlug: string, email: string) {
+  const user = await getOrCreateUserByEmail(email);
+  const [existing] = await db
+    .select()
+    .from(favorites)
+    .where(and(eq(favorites.userId, user.id), eq(favorites.appSlug, appSlug)));
+
+  if (existing) {
+    await db
+      .delete(favorites)
+      .where(and(eq(favorites.userId, user.id), eq(favorites.appSlug, appSlug)));
+  } else {
+    await db.insert(favorites).values({ userId: user.id, appSlug });
+  }
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,4 +1,10 @@
-import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import {
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  primaryKey,
+} from "drizzle-orm/pg-core";
 
 export const users = pgTable("users", {
   id: uuid("id").defaultRandom().primaryKey(),
@@ -12,3 +18,17 @@ export const users = pgTable("users", {
 export const allowedUsers = pgTable("allowed_users", {
   email: text("email").primaryKey(),
 });
+
+export const favorites = pgTable(
+  "favorites",
+  {
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    appSlug: text("app_slug").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.userId, table.appSlug] }),
+  })
+);


### PR DESCRIPTION
## Summary
- derive app list at build time from `apps/*/meta.json`
- store favorites by app slug and drop unused apps table
- document static app registry in PRD
- merge initial favorites migrations into a single script

## Testing
- `pnpm lint`
- `CI=1 GOOGLE_CLIENT_ID=foo GOOGLE_CLIENT_SECRET=bar AUTH_SECRET=secret DATABASE_URL=postgres://user:pass@localhost:5432/db pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ab75fb6814832593055879e03cfc7d