### PR TITLE
fix: sync pnpm lockfile with package.json

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      jose:
+        specifier: ^4.15.5
+        version: 4.15.9
       mongodb:
         specifier: ^6.3.0
         version: 6.19.0


### PR DESCRIPTION
## Summary
- update pnpm lockfile to include jose dependency

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b0427a95d88325af36f3c7d386f4e9