### PR TITLE
fix(auth): force production redirect for oauth

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,10 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import { encode as encodeJwt } from "next-auth/jwt";
+import { PRODUCTION_ORIGIN } from "./config";
+
+// Ensure Google OAuth redirect URI always uses the production domain
+process.env.NEXTAUTH_URL = PRODUCTION_ORIGIN;
 
 const allowedEmails = (process.env.ALLOWED_EMAILS || "")
   .split(",")


### PR DESCRIPTION
## Summary
- ensure Auth.js always uses production domain for OAuth redirect

## Testing
- `pnpm lint`
- `MONGODB_URI="mongodb://localhost:27017/test" pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b0888ad0048325a46a8a62ff09aa4d