### PR TITLE
chore: add preview redirect logging

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,14 @@ import { PREVIEW_HOST_PATTERN, PRODUCTION_ORIGIN } from "./src/lib/config";
 
 export default auth(async (req) => {
   const url = req.nextUrl;
-  if (PREVIEW_HOST_PATTERN.test(url.host)) {
+  const isPreview = PREVIEW_HOST_PATTERN.test(url.host);
+  console.log("[middleware] request", {
+    host: url.host,
+    isPreview,
+    hasSession: !!req.cookies.get("session"),
+    href: url.href,
+  });
+  if (isPreview) {
     const token = req.cookies.get("session")?.value;
     if (token) {
       try {
@@ -15,12 +22,14 @@ export default auth(async (req) => {
     }
     const signInUrl = new URL(`${PRODUCTION_ORIGIN}/api/auth/signin`);
     signInUrl.searchParams.set("from", url.href);
+    console.log("[middleware] redirecting to prod signin", signInUrl.toString());
     return NextResponse.redirect(signInUrl);
   }
 
   if (!(req as any).auth) {
     const signInUrl = new URL("/api/auth/signin", url);
     signInUrl.searchParams.set("callbackUrl", url.href);
+    console.log("[middleware] redirecting to local signin", signInUrl.toString());
     return NextResponse.redirect(signInUrl);
   }
 });


### PR DESCRIPTION
## Summary
- log middleware requests and redirect targets to debug preview auth flow

## Testing
- `pnpm lint`
- `MONGODB_URI=mongodb://localhost:27017/test pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b0a76dde4c832585d73277711a67a5