### PR TITLE
fix: lazy load MongoDB at runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ This document defines how autonomous or semi‑autonomous AI agents collaborate 
 * **Branching.** `main` (protected). Features: `feat/<area>-<short>`.
 * **Commits.** Conventional style: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`.
 * **PR template.** Checklist includes: linked issue, screenshots, a11y notes, perf notes, and risk.
-* **CI (lightweight).** Typecheck, lint, build, run minimal tests. Block on failing checks.
+* **CI (lightweight).** Typecheck, lint, build, run minimal tests. Block on failing checks. Run build as `CI=1 npm run build`.
 * **Ownership.** Each sub‑app names an Owner in its `AGENTS.md`.
 
 ## 3) Repository Layout (High Level)

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,16 @@
-import { MongoClient } from "mongodb";
+import { MongoClient, Db } from "mongodb";
 
-const client = new MongoClient(process.env.MONGODB_URI!);
+let client: MongoClient | undefined;
+let db: Db | undefined;
 
-export const db = client.db();
+export async function getDb(): Promise<Db> {
+  if (db) return db;
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    throw new Error("MONGODB_URI is not set");
+  }
+  client = new MongoClient(uri);
+  await client.connect();
+  db = client.db();
+  return db;
+}

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -1,9 +1,10 @@
 import { ObjectId } from "mongodb";
-import { db } from "./db";
+import { getDb } from "./db";
 import { allApps } from "./apps";
 import type { User, Favorite } from "./schema";
 
 export async function getOrCreateUserByEmail(email: string) {
+  const db = await getDb();
   const users = db.collection<User>("users");
   const existing = await users.findOne({ email });
   if (existing) return existing;
@@ -40,6 +41,7 @@ export async function getApps(search: string, email?: string) {
 }
 
 export async function toggleFavorite(appSlug: string, email: string) {
+  const db = await getDb();
   const users = db.collection<User>("users");
   const user = await getOrCreateUserByEmail(email);
   const exists = user.favorites?.some((f) => f.appSlug === appSlug);


### PR DESCRIPTION
## Summary
- use a lazy `getDb` helper so MongoDB connection happens only at runtime
- fetch the db inside registry helpers instead of importing it at build time
- document that builds must be run with `CI=1`

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `CI=1 npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0c094f7948325ac31f8ff37c7d4c1