### PR TITLE
feat: require manual redirect on auth relay

### DIFF
--- a/src/app/auth/relay/page.tsx
+++ b/src/app/auth/relay/page.tsx
@@ -8,14 +8,30 @@ export default async function Relay({
   const session = await auth();
   const token = (session as any)?.jwt;
   const from = searchParams.from;
+  const redirectUrl = from && token ? `${from}#token=${token}` : undefined;
   const script = `const from = ${JSON.stringify(
-    from || ""
+    from || "",
   )}; const token = ${JSON.stringify(
-    token || ""
-  )}; if (from && token) { window.location.replace(from + '#token=' + token); }`;
+    token || "",
+  )}; const redirectUrl = from && token ? from + '#token=' + token : null; document.getElementById('redirect-btn')?.addEventListener('click', function () { if (redirectUrl) { window.location.replace(redirectUrl); } });`;
   return (
     <html>
       <body>
+        <main>
+          <h1>Auth Relay</h1>
+          <p>
+            <strong>from:</strong> {from ?? "(missing)"}
+          </p>
+          <p>
+            <strong>token:</strong> {token ?? "(missing)"}
+          </p>
+          <p>
+            <strong>redirect:</strong> {redirectUrl ?? "(none)"}
+          </p>
+          <button id="redirect-btn" disabled={!redirectUrl}>
+            Continue
+          </button>
+        </main>
         <script dangerouslySetInnerHTML={{ __html: script }} />
       </body>
     </html>


### PR DESCRIPTION
## Summary
- require button press before relay redirect
- show received params and calculated redirect target

## Testing
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `CI=1 pnpm build`
- `pnpm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b17b0e717c8325a5cf22c9b5c5537e