### PR TITLE
feat: add token auth flow for previews

### DIFF
--- a/src/app/me/token/route.ts
+++ b/src/app/me/token/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+import { SignJWT } from "jose";
+import { auth } from "../../../lib/auth";
+
+export async function GET(req: NextRequest) {
+  const session = await auth(req);
+  const email = session?.user?.email;
+  if (!email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const callbackUrl = req.nextUrl.searchParams.get("callbackUrl");
+  if (!callbackUrl) {
+    return NextResponse.json({ error: "callbackUrl required" }, { status: 400 });
+  }
+  const token = await new SignJWT({ email })
+    .setProtectedHeader({ alg: "HS256", typ: "JWT" })
+    .setIssuedAt()
+    .setExpirationTime("1h")
+    .sign(new TextEncoder().encode(process.env.AUTH_SECRET!));
+  const url = new URL(callbackUrl);
+  url.searchParams.set("token", token);
+  return NextResponse.redirect(url);
+}


### PR DESCRIPTION
## Summary
- add `/me/token` endpoint to issue JWT for authenticated users and redirect to a callback URL
- verify preview tokens via custom auth helper and middleware, bypassing Google OAuth on previews
- document updated preview authentication flow in PRD

## Testing
- `pnpm lint`
- `CI=1 pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b1fe6cb7cc8325bbb1323d5f2b35c0