### PR TITLE
fix: trust host for next-auth

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,6 +18,11 @@ const nextAuth = NextAuth({
     }),
   ],
   secret: process.env.AUTH_SECRET,
+  // When `NEXTAUTH_URL` is set, NextAuth rebuilds the request via
+  // `new NextRequest()` which isn't available in some runtimes and
+  // causes "on is not a constructor" errors. Trust the incoming host
+  // header instead to avoid this rewrite.
+  trustHost: true,
   callbacks: {
     async signIn({ user }) {
       if (!user.email) return false;


### PR DESCRIPTION
## Summary
- trust host header so NextAuth doesn't rebuild request with `NextRequest`
- document why this avoids "on is not a constructor" errors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2061f641c8325ad6267eab6f6b331